### PR TITLE
Для сообществ random_id может равняться нулю при каждом запросе

### DIFF
--- a/python/bot.py
+++ b/python/bot.py
@@ -1,5 +1,3 @@
-from random import randint
-
 from saya import Vk
 from social_ethosa import BetterBotBase
 from datetime import datetime, timedelta

--- a/python/bot.py
+++ b/python/bot.py
@@ -302,7 +302,7 @@ class V(Vk):
     def send_message(self, event, message):
         self.messages.send(
             message=message, peer_id=event["peer_id"],
-            disable_mentions=1, random_id=randint(-INT32, INT32)
+            disable_mentions=1, random_id=0
         )
 
 


### PR DESCRIPTION
Из-за отсутствия нумерации айди сообщения вк позволяет для отправки сообщений в random_id указывать 0.