### PR TITLE
Start review scary rust code from `decode_github_content`:

### DIFF
--- a/rust/update-conan-recipe-and-create-pull-request/rustfmt.toml
+++ b/rust/update-conan-recipe-and-create-pull-request/rustfmt.toml
@@ -1,0 +1,6 @@
+error_on_line_overflow = true
+error_on_unformatted = true
+version = "Two"
+
+imports_granularity = "One"
+use_small_heuristics = "Max"

--- a/rust/update-conan-recipe-and-create-pull-request/src/decode_github_content.rs
+++ b/rust/update-conan-recipe-and-create-pull-request/src/decode_github_content.rs
@@ -1,17 +1,29 @@
-use base64::Engine;
-use crate::add_version_to_conandata_yml::AddVersionToConandataYmlArgument;
+use {crate::Result, base64::DecodeError};
 
+#[deprecated]
 pub struct DecodeGithubContentArgument<'a> {
     pub content: &'a String,
 }
 
-pub fn decode_github_content(argument: &DecodeGithubContentArgument<'_>) -> Option<String> {
-    let DecodeGithubContentArgument {
-        content
-    } = argument;
-    let mut content_without_github_shit = content.as_bytes().to_owned();
-    content_without_github_shit.retain(|b| !b" \n\t\r\x0b\x0c".contains(b));
-    let decoded_content = base64::engine::general_purpose::STANDARD
-        .decode(&content_without_github_shit).unwrap();
-    Some(String::from_utf8_lossy(&decoded_content).into_owned())
+#[deprecated(note = "keep `decode_github_content` for soft migration into `decode`")]
+pub fn decode_github_content(
+    &DecodeGithubContentArgument { content }: &DecodeGithubContentArgument,
+) -> Option<String> {
+    decode(
+        // This leads to unnecessary cloning
+        content.clone(),
+    )
+    .ok()
+}
+
+// use `String` because it is useful for `octorust` types
+pub fn decode(mut content: String) -> Result<String, DecodeError> {
+    // base64 alphabet is always utf8 safe
+    Ok(unsafe {
+        // `base64::decode` is deprecated but it is very simple use case
+        String::from_utf8_unchecked(base64::decode({
+            content.retain(|b| !b.is_whitespace());
+            content.into_bytes()
+        })?)
+    })
 }

--- a/rust/update-conan-recipe-and-create-pull-request/src/main.rs
+++ b/rust/update-conan-recipe-and-create-pull-request/src/main.rs
@@ -1,4 +1,6 @@
-extern crate core;
+#![deny(clippy::all, clippy::perf)] // `clippy::perf` will teach you to write good code always
+
+pub(crate) use anyhow::Result;
 
 use std::error::Error;
 use std::iter::zip;


### PR DESCRIPTION
- keep old `deprecated` function
- use normal `fn` args instead of `struct`
- avoid long names
- add `rustfmt.toml` and deny clippy lints