### PR TITLE
TraderBot: Remove LoadOperationsFrom from config and implement automatic calculation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Bot/issues/245
+Your prepared branch: issue-245-4d69fcab
+Your prepared working directory: /tmp/gh-issue-solver-1757574869564
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Bot/issues/245
-Your prepared branch: issue-245-4d69fcab
-Your prepared working directory: /tmp/gh-issue-solver-1757574869564
-
-Proceed.

--- a/csharp/TraderBot/README.md
+++ b/csharp/TraderBot/README.md
@@ -78,7 +78,6 @@ Configuration is located in `appsettings.json` file.
 | `TradingSettings`/`MinimumMarketOrderSizeToSell` | Minimum size of the market order to sell. The price will be not acceptable unless there is that much lots on the market at this price. |
 | `TradingSettings`/`EarlySellOwnedLotsDelta` | A constant component of the minimum number of lots that the market order placed at the buy price should have in order to trigger the immediate sell order. Complete formula: (`TradingSettings`/`EarlySellOwnedLotsDelta` + `TradingSettings`/`EarlySellOwnedLotsMultiplier` * `Lots requested to sell`). |
 | `TradingSettings`/`EarlySellOwnedLotsMultiplier` | A multiplier of lots requested to sell. A component of the minimum number of lots that the market order placed at the buy price should have in order to trigger the immediate sell order. Complete formula: (`TradingSettings`/`EarlySellOwnedLotsDelta` + `TradingSettings`/`EarlySellOwnedLotsMultiplier` * `Lots requested to sell`). |
-| `TradingSettings`/`LoadOperationsFrom` | Minimum data and time to load operations from. |
 
 ## Current default trading time-frame
 

--- a/csharp/TraderBot/TradingService.cs
+++ b/csharp/TraderBot/TradingService.cs
@@ -62,8 +62,6 @@ public class TradingService : BackgroundService
         Logger.LogInformation($"MaximumTimeToBuy: {MaximumTimeToBuy}");
         Logger.LogInformation($"EarlySellOwnedLotsDelta: {settings.EarlySellOwnedLotsDelta}");
         Logger.LogInformation($"EarlySellOwnedLotsMultiplier: {settings.EarlySellOwnedLotsMultiplier}");
-        Logger.LogInformation($"LoadOperationsFrom: {settings.LoadOperationsFrom}");
-
         var currentTime = DateTime.UtcNow.TimeOfDay;
         Logger.LogInformation($"Current time: {currentTime}");
 
@@ -111,7 +109,23 @@ public class TradingService : BackgroundService
         ActiveSellOrders = new ConcurrentDictionary<string, OrderState>();
         LotsSets = new ConcurrentDictionary<decimal, long>();
         ActiveSellOrderSourcePrice = new ConcurrentDictionary<string, decimal>();
-        LastOperationsCheckpoint = settings.LoadOperationsFrom;
+        
+        // Calculate LoadOperationsFrom automatically if not provided
+        DateTime calculatedLoadOperationsFrom;
+        if (settings.LoadOperationsFrom.HasValue)
+        {
+            calculatedLoadOperationsFrom = settings.LoadOperationsFrom.Value;
+            Logger.LogInformation($"LoadOperationsFrom (from config): {calculatedLoadOperationsFrom}");
+        }
+        else
+        {
+            // Use account open date or 30 days ago, whichever is more recent
+            DateTime accountOpenDate = DateTime.SpecifyKind(CurrentAccount.OpenedDate.ToDateTime(), DateTimeKind.Utc);
+            DateTime thirtyDaysAgo = DateTime.UtcNow.AddDays(-30);
+            calculatedLoadOperationsFrom = new[] { accountOpenDate, thirtyDaysAgo }.Max();
+            Logger.LogInformation($"LoadOperationsFrom (calculated automatically): {calculatedLoadOperationsFrom}");
+        }
+        LastOperationsCheckpoint = calculatedLoadOperationsFrom;
     }
 
     protected async Task ReceiveTrades(CancellationToken cancellationToken)

--- a/csharp/TraderBot/TradingSettings.cs
+++ b/csharp/TraderBot/TradingSettings.cs
@@ -16,5 +16,5 @@ public class TradingSettings
     public string? MaximumTimeToBuy { get; set; }
     public long EarlySellOwnedLotsDelta { get; set; }
     public decimal EarlySellOwnedLotsMultiplier { get; set; }
-    public DateTime LoadOperationsFrom { get; set; }
+    public DateTime? LoadOperationsFrom { get; set; }
 }

--- a/csharp/TraderBot/appsettings.TMON.json
+++ b/csharp/TraderBot/appsettings.TMON.json
@@ -23,7 +23,6 @@
     "MinimumTimeToBuy": "00:00:01",
     "MaximumTimeToBuy": "23:59:59",
     "EarlySellOwnedLotsDelta": 300000,
-    "EarlySellOwnedLotsMultiplier": 0,
-    "LoadOperationsFrom": "2025-03-01T00:00:01.3389860Z"
+    "EarlySellOwnedLotsMultiplier": 0
   }
 }

--- a/csharp/TraderBot/appsettings.TRUR.json
+++ b/csharp/TraderBot/appsettings.TRUR.json
@@ -23,7 +23,6 @@
     "MinimumTimeToBuy": "09:00:00",
     "MaximumTimeToBuy": "14:45:00",
     "EarlySellOwnedLotsDelta": 300000,
-    "EarlySellOwnedLotsMultiplier": 0,
-    "LoadOperationsFrom": "2025-03-01T00:00:01.3389860Z"
+    "EarlySellOwnedLotsMultiplier": 0
   }
 }


### PR DESCRIPTION
## Summary
- Removed the `LoadOperationsFrom` setting from configuration files (`appsettings.TMON.json` and `appsettings.TRUR.json`)
- Implemented automatic calculation of the operations loading start date
- The system now automatically uses the maximum of either the account open date or 30 days ago as the starting point

## Problem Solved
The manual `LoadOperationsFrom` setting was prone to becoming stale and causing errors when not updated regularly. This change eliminates the need for manual maintenance of this setting.

## Implementation Details
- Made `LoadOperationsFrom` property nullable in `TradingSettings` class
- Added automatic calculation logic in the `TradingService` constructor
- The calculation uses `Max(accountOpenDate, thirtyDaysAgo)` to determine the optimal starting point
- Added informative logging to show whether the value came from configuration or was calculated automatically
- Updated documentation in `README.md` to remove the obsolete setting

## Test plan
- [x] Code compiles successfully with no new errors
- [x] Build passes without issues
- [x] Automatic calculation logic handles both nullable and configured scenarios
- [x] Logging provides clear information about the calculated value
- [x] Documentation updated to reflect the changes

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #245