### PR TITLE
Trader Bot: Implement buy prevention logic for problematic market conditions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Bot/issues/224
-Your prepared branch: issue-224-c1707416
-Your prepared working directory: /tmp/gh-issue-solver-1757581429232
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Bot/issues/224
+Your prepared branch: issue-224-c1707416
+Your prepared working directory: /tmp/gh-issue-solver-1757581429232
+
+Proceed.

--- a/csharp/TraderBot/TradingService.cs
+++ b/csharp/TraderBot/TradingService.cs
@@ -63,6 +63,8 @@ public class TradingService : BackgroundService
         Logger.LogInformation($"EarlySellOwnedLotsDelta: {settings.EarlySellOwnedLotsDelta}");
         Logger.LogInformation($"EarlySellOwnedLotsMultiplier: {settings.EarlySellOwnedLotsMultiplier}");
         Logger.LogInformation($"LoadOperationsFrom: {settings.LoadOperationsFrom}");
+        Logger.LogInformation($"MaxSpreadPercentToBuy: {settings.MaxSpreadPercentToBuy}");
+        Logger.LogInformation($"MinimumCombinedLiquidityToBuy: {settings.MinimumCombinedLiquidityToBuy}");
 
         var currentTime = DateTime.UtcNow.TimeOfDay;
         Logger.LogInformation($"Current time: {currentTime}");
@@ -468,7 +470,7 @@ public class TradingService : BackgroundService
                     }
                     if (!areOrdersPlaced)
                     {
-                        if (IsTimeToBuy())
+                        if (IsTimeToBuy() && IsMarketConditionsSuitableForBuying(bestBid, bestAsk, orderBook))
                         {
                             // Process potential buy order
                             var (cashBalance, _) = await GetCashBalance();
@@ -516,7 +518,7 @@ public class TradingService : BackgroundService
                 else if (ActiveBuyOrders.Count == 1)
                 {
                     var activeBuyOrder = ActiveBuyOrders.Single().Value;
-                    if (IsTimeToBuy())
+                    if (IsTimeToBuy() && IsMarketConditionsSuitableForBuying(bestBid, bestAsk, orderBook))
                     {
                         var initialOrderPrice = MoneyValueToDecimal(activeBuyOrder.InitialSecurityPrice);
                         if (LotsSets.TryGetValue(initialOrderPrice, out var boughtLots) || LotsSets.Count == 0)
@@ -569,7 +571,7 @@ public class TradingService : BackgroundService
                     }
                     else
                     {
-                        Logger.LogInformation($"It is not time to buy, cancelling buy order");
+                        Logger.LogInformation($"Conditions not suitable for buying, cancelling buy order");
                         // Cancel order
                         if (!await TryCancelOrder(activeBuyOrder.OrderId))
                         {
@@ -652,6 +654,30 @@ public class TradingService : BackgroundService
     {
        var currentTime = DateTime.UtcNow.TimeOfDay;
        return currentTime > MinimumTimeToBuy && currentTime < MaximumTimeToBuy;
+    }
+
+    private bool IsMarketConditionsSuitableForBuying(decimal bestBid, decimal bestAsk, OrderBook orderBook)
+    {
+        // Check if spread is not too wide
+        var spread = bestAsk - bestBid;
+        var spreadPercent = (spread / bestBid) * 100;
+        if (spreadPercent > Settings.MaxSpreadPercentToBuy)
+        {
+            Logger.LogInformation($"Spread too wide for buying: {spreadPercent:F2}% (max allowed: {Settings.MaxSpreadPercentToBuy}%)");
+            return false;
+        }
+
+        // Check combined liquidity at best bid and ask
+        var bestBidOrder = orderBook.Bids.FirstOrDefault();
+        var bestAskOrder = orderBook.Asks.FirstOrDefault();
+        var combinedLiquidity = (bestBidOrder?.Quantity ?? 0) + (bestAskOrder?.Quantity ?? 0);
+        if (combinedLiquidity < Settings.MinimumCombinedLiquidityToBuy)
+        {
+            Logger.LogInformation($"Insufficient liquidity for buying: {combinedLiquidity} (minimum required: {Settings.MinimumCombinedLiquidityToBuy})");
+            return false;
+        }
+
+        return true;
     } 
 
     private async Task<(decimal, decimal)> GetCashBalance(bool forceRemote = false)

--- a/csharp/TraderBot/TradingSettings.cs
+++ b/csharp/TraderBot/TradingSettings.cs
@@ -17,4 +17,6 @@ public class TradingSettings
     public long EarlySellOwnedLotsDelta { get; set; }
     public decimal EarlySellOwnedLotsMultiplier { get; set; }
     public DateTime LoadOperationsFrom { get; set; }
+    public decimal MaxSpreadPercentToBuy { get; set; }
+    public long MinimumCombinedLiquidityToBuy { get; set; }
 }

--- a/csharp/TraderBot/appsettings.TMON.json
+++ b/csharp/TraderBot/appsettings.TMON.json
@@ -24,6 +24,8 @@
     "MaximumTimeToBuy": "23:59:59",
     "EarlySellOwnedLotsDelta": 300000,
     "EarlySellOwnedLotsMultiplier": 0,
-    "LoadOperationsFrom": "2025-03-01T00:00:01.3389860Z"
+    "LoadOperationsFrom": "2025-03-01T00:00:01.3389860Z",
+    "MaxSpreadPercentToBuy": 1.0,
+    "MinimumCombinedLiquidityToBuy": 1000000
   }
 }

--- a/csharp/TraderBot/appsettings.TRUR.json
+++ b/csharp/TraderBot/appsettings.TRUR.json
@@ -24,6 +24,8 @@
     "MaximumTimeToBuy": "14:45:00",
     "EarlySellOwnedLotsDelta": 300000,
     "EarlySellOwnedLotsMultiplier": 0,
-    "LoadOperationsFrom": "2025-03-01T00:00:01.3389860Z"
+    "LoadOperationsFrom": "2025-03-01T00:00:01.3389860Z",
+    "MaxSpreadPercentToBuy": 1.0,
+    "MinimumCombinedLiquidityToBuy": 1000000
   }
 }


### PR DESCRIPTION
## Summary

This PR implements buy prevention logic to avoid buying when market conditions make it difficult to sell later at a profit, addressing issue #224.

### Changes Made

- **New Configuration Settings:**
  - `MaxSpreadPercentToBuy`: Maximum allowed bid-ask spread percentage (default: 1.0%)
  - `MinimumCombinedLiquidityToBuy`: Minimum required combined liquidity at best bid/ask (default: 1,000,000)

- **New Market Condition Checks:**
  - Added `IsMarketConditionsSuitableForBuying()` method that checks:
    - Bid-ask spread is not too wide (prevents buying when spread makes profit difficult)
    - Combined market liquidity is sufficient (prevents buying in illiquid markets)

- **Applied Prevention Logic to:**
  - Initial buy order placement (line ~473)
  - Buy order price change logic (line ~521)
  - Automatic buy order cancellation when conditions become unsuitable

### Configuration Updates

Updated both `appsettings.TMON.json` and `appsettings.TRUR.json` with sensible default values:
- MaxSpreadPercentToBuy: 1.0% (prevents buying when spread is too wide)
- MinimumCombinedLiquidityToBuy: 1,000,000 (ensures sufficient market liquidity)

### How It Works

The bot will now refuse to buy when:
1. **Wide Spreads**: The bid-ask spread exceeds the configured percentage threshold
2. **Low Liquidity**: The combined order size at best bid and ask is below the minimum threshold

This prevents the scenario described in issue #224 where the bot would buy in conditions that make it "much harder to sell" later.

## Test Plan

- [x] Code compiles successfully in both Debug and Release modes
- [x] No runtime errors introduced
- [x] Configuration settings properly logged on startup
- [x] Buy prevention logic applied to all relevant code paths

## Related Issues

Fixes #224

🤖 Generated with [Claude Code](https://claude.ai/code)