### PR TITLE
Trader: add automatic profit calculation (both in relative and absolute values)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Bot/issues/201
+Your prepared branch: issue-201-2e517753
+Your prepared working directory: /tmp/gh-issue-solver-1757583901698
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Bot/issues/201
-Your prepared branch: issue-201-2e517753
-Your prepared working directory: /tmp/gh-issue-solver-1757583901698
-
-Proceed.

--- a/csharp/TraderBot/ProfitCalculationService.Tests.cs
+++ b/csharp/TraderBot/ProfitCalculationService.Tests.cs
@@ -1,0 +1,178 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Tinkoff.InvestApi.V1;
+using Xunit;
+
+namespace TraderBot.Tests;
+
+using OperationsList = List<(OperationType Type, DateTime Date, long Quantity, decimal Price)>;
+
+public class ProfitCalculationServiceTests
+{
+    private readonly ProfitCalculationService _service;
+    private readonly Mock<ILogger<ProfitCalculationService>> _mockLogger;
+
+    public ProfitCalculationServiceTests()
+    {
+        _mockLogger = new Mock<ILogger<ProfitCalculationService>>();
+        _service = new ProfitCalculationService(_mockLogger.Object);
+    }
+
+    [Fact]
+    public void CalculateProfit_EmptyOperations_ReturnsZeroProfit()
+    {
+        // Arrange
+        var operations = new OperationsList();
+
+        // Act
+        var result = _service.CalculateProfit(operations);
+
+        // Assert
+        Assert.Equal(0, result.TotalAbsoluteProfit);
+        Assert.Equal(0, result.TotalRelativeProfit);
+        Assert.Equal(0, result.RealizedAbsoluteProfit);
+        Assert.Equal(0, result.RealizedRelativeProfit);
+        Assert.Equal(0, result.UnrealizedAbsoluteProfit);
+        Assert.Equal(0, result.UnrealizedRelativeProfit);
+        Assert.Equal(0, result.OpenPositionQuantity);
+        Assert.Empty(result.CompletedTrades);
+    }
+
+    [Fact]
+    public void CalculateProfit_OnlyBuyOperations_ShowsUnrealizedProfit()
+    {
+        // Arrange
+        var operations = new OperationsList
+        {
+            (OperationType.Buy, DateTime.Now.AddHours(-2), 10, 100.0m),
+            (OperationType.Buy, DateTime.Now.AddHours(-1), 5, 110.0m)
+        };
+        var currentPrice = 120.0m;
+
+        // Act
+        var result = _service.CalculateProfit(operations, currentPrice);
+
+        // Assert
+        Assert.Equal(15, result.OpenPositionQuantity);
+        Assert.Equal(1550.0m, result.TotalInvested); // (10*100) + (5*110)
+        Assert.Equal(103.33m, Math.Round(result.AverageBuyPrice, 2)); // 1550/15
+        Assert.Equal(1800.0m - 1550.0m, result.UnrealizedAbsoluteProfit); // (15*120) - 1550
+        Assert.Equal(250.0m, result.UnrealizedAbsoluteProfit);
+        Assert.Equal(Math.Round((250.0m / 1550.0m) * 100, 2), Math.Round(result.UnrealizedRelativeProfit, 2)); // ~16.13%
+        Assert.Equal(0, result.RealizedAbsoluteProfit);
+        Assert.Empty(result.CompletedTrades);
+    }
+
+    [Fact]
+    public void CalculateProfit_BuyAndSellOperations_ShowsRealizedProfit()
+    {
+        // Arrange
+        var operations = new OperationsList
+        {
+            (OperationType.Buy, DateTime.Now.AddHours(-3), 10, 100.0m),
+            (OperationType.Buy, DateTime.Now.AddHours(-2), 5, 110.0m),
+            (OperationType.Sell, DateTime.Now.AddHours(-1), 8, 120.0m)
+        };
+        var currentPrice = 115.0m;
+
+        // Act
+        var result = _service.CalculateProfit(operations, currentPrice);
+
+        // Assert
+        // Realized profit: First 8 lots sold at 120, bought at 100 (FIFO)
+        // 8 * (120 - 100) = 160
+        Assert.Equal(160.0m, result.RealizedAbsoluteProfit);
+        
+        // Remaining position: 2 lots at 100 + 5 lots at 110 = 7 lots
+        Assert.Equal(7, result.OpenPositionQuantity);
+        Assert.Equal(750.0m, result.TotalInvested); // (2*100) + (5*110)
+        
+        // Unrealized profit: 7 lots at current price 115 vs invested 750
+        var currentValue = 7 * 115.0m; // 805
+        var unrealizedProfit = currentValue - 750.0m; // 55
+        Assert.Equal(55.0m, result.UnrealizedAbsoluteProfit);
+        
+        // Total profit = realized + unrealized
+        Assert.Equal(215.0m, result.TotalAbsoluteProfit); // 160 + 55
+        
+        // Should have one completed trade
+        Assert.Single(result.CompletedTrades);
+        Assert.Equal(8, result.CompletedTrades[0].Quantity);
+        Assert.Equal(100.0m, result.CompletedTrades[0].BuyPrice);
+        Assert.Equal(120.0m, result.CompletedTrades[0].SellPrice);
+        Assert.Equal(160.0m, result.CompletedTrades[0].AbsoluteProfit);
+    }
+
+    [Fact]
+    public void CalculateProfit_MultipleBuysAndSells_FIFO_Matching()
+    {
+        // Arrange
+        var operations = new OperationsList
+        {
+            (OperationType.Buy, DateTime.Now.AddHours(-6), 10, 100.0m),   // Buy 10 @ 100
+            (OperationType.Buy, DateTime.Now.AddHours(-5), 5, 110.0m),    // Buy 5 @ 110
+            (OperationType.Sell, DateTime.Now.AddHours(-4), 3, 120.0m),   // Sell 3 @ 120 (from first buy)
+            (OperationType.Sell, DateTime.Now.AddHours(-3), 7, 125.0m),   // Sell 7 @ 125 (remaining 7 from first buy)
+            (OperationType.Buy, DateTime.Now.AddHours(-2), 8, 105.0m),    // Buy 8 @ 105
+            (OperationType.Sell, DateTime.Now.AddHours(-1), 2, 130.0m)    // Sell 2 @ 130 (from second buy)
+        };
+
+        // Act
+        var result = _service.CalculateProfit(operations);
+
+        // Assert
+        // Completed trades:
+        // Trade 1: 3 lots @ 100 -> 120 = 3 * (120-100) = 60
+        // Trade 2: 7 lots @ 100 -> 125 = 7 * (125-100) = 175  
+        // Trade 3: 2 lots @ 110 -> 130 = 2 * (130-110) = 40
+        // Total realized: 60 + 175 + 40 = 275
+        Assert.Equal(275.0m, result.RealizedAbsoluteProfit);
+        
+        // Remaining positions:
+        // 3 lots from second buy @ 110
+        // 8 lots from third buy @ 105
+        // Total: 11 lots, value: (3*110) + (8*105) = 330 + 840 = 1170
+        Assert.Equal(11, result.OpenPositionQuantity);
+        Assert.Equal(1170.0m, result.TotalInvested);
+        
+        // Should have 3 completed trades
+        Assert.Equal(3, result.CompletedTrades.Count);
+    }
+
+    [Fact]
+    public void CalculateProfit_ProfitableTrade_CorrectRelativePercentage()
+    {
+        // Arrange
+        var operations = new OperationsList
+        {
+            (OperationType.Buy, DateTime.Now.AddHours(-2), 10, 100.0m),   // Invest 1000
+            (OperationType.Sell, DateTime.Now.AddHours(-1), 10, 110.0m)   // Sell for 1100
+        };
+
+        // Act
+        var result = _service.CalculateProfit(operations);
+
+        // Assert
+        Assert.Equal(100.0m, result.RealizedAbsoluteProfit); // 1100 - 1000
+        Assert.Equal(10.0m, result.RealizedRelativeProfit);  // (100/1000) * 100 = 10%
+        Assert.Equal(0, result.OpenPositionQuantity); // All positions closed
+    }
+
+    [Fact]
+    public void CalculateProfit_LossTrade_NegativeProfit()
+    {
+        // Arrange
+        var operations = new OperationsList
+        {
+            (OperationType.Buy, DateTime.Now.AddHours(-2), 10, 100.0m),   // Invest 1000
+            (OperationType.Sell, DateTime.Now.AddHours(-1), 10, 90.0m)    // Sell for 900
+        };
+
+        // Act
+        var result = _service.CalculateProfit(operations);
+
+        // Assert
+        Assert.Equal(-100.0m, result.RealizedAbsoluteProfit); // 900 - 1000
+        Assert.Equal(-10.0m, result.RealizedRelativeProfit);  // (-100/1000) * 100 = -10%
+    }
+}

--- a/csharp/TraderBot/ProfitCalculationService.cs
+++ b/csharp/TraderBot/ProfitCalculationService.cs
@@ -1,0 +1,185 @@
+using Microsoft.Extensions.Logging;
+using Tinkoff.InvestApi.V1;
+
+namespace TraderBot;
+
+using OperationsList = List<(OperationType Type, DateTime Date, long Quantity, decimal Price)>;
+
+public class ProfitCalculationService
+{
+    private readonly ILogger<ProfitCalculationService> Logger;
+
+    public ProfitCalculationService(ILogger<ProfitCalculationService> logger)
+    {
+        Logger = logger;
+    }
+
+    public ProfitAnalysis CalculateProfit(OperationsList operations, decimal currentPrice = 0)
+    {
+        if (operations == null || !operations.Any())
+        {
+            return new ProfitAnalysis
+            {
+                TotalAbsoluteProfit = 0,
+                TotalRelativeProfit = 0,
+                RealizedAbsoluteProfit = 0,
+                RealizedRelativeProfit = 0,
+                UnrealizedAbsoluteProfit = 0,
+                UnrealizedRelativeProfit = 0,
+                TotalInvested = 0,
+                OpenPositionQuantity = 0,
+                AverageBuyPrice = 0,
+                CompletedTrades = new List<TradeProfit>()
+            };
+        }
+
+        var analysis = new ProfitAnalysis();
+        var completedTrades = new List<TradeProfit>();
+        var openBuyOperations = new List<(OperationType Type, DateTime Date, long Quantity, decimal Price)>();
+        
+        decimal totalBought = 0;
+        decimal totalSold = 0;
+        long totalBoughtQuantity = 0;
+        long totalSoldQuantity = 0;
+        
+        // Separate buy and sell operations
+        var buyOperations = operations.Where(o => o.Type == OperationType.Buy).OrderBy(o => o.Date).ToList();
+        var sellOperations = operations.Where(o => o.Type == OperationType.Sell).OrderBy(o => o.Date).ToList();
+
+        // Calculate completed trades (FIFO matching)
+        var remainingBuyOps = buyOperations.ToList();
+        
+        foreach (var sellOp in sellOperations)
+        {
+            var remainingSellQuantity = sellOp.Quantity;
+            
+            while (remainingSellQuantity > 0 && remainingBuyOps.Any())
+            {
+                var firstBuy = remainingBuyOps.First();
+                var matchedQuantity = Math.Min(remainingSellQuantity, firstBuy.Quantity);
+                
+                // Calculate profit for this matched trade
+                var buyValue = matchedQuantity * firstBuy.Price;
+                var sellValue = matchedQuantity * sellOp.Price;
+                var absoluteProfit = sellValue - buyValue;
+                var relativeProfit = buyValue > 0 ? (absoluteProfit / buyValue) * 100 : 0;
+                
+                completedTrades.Add(new TradeProfit
+                {
+                    BuyDate = firstBuy.Date,
+                    SellDate = sellOp.Date,
+                    Quantity = matchedQuantity,
+                    BuyPrice = firstBuy.Price,
+                    SellPrice = sellOp.Price,
+                    AbsoluteProfit = absoluteProfit,
+                    RelativeProfit = relativeProfit
+                });
+                
+                // Update totals
+                totalSold += sellValue;
+                totalSoldQuantity += matchedQuantity;
+                
+                // Update remaining quantities
+                remainingSellQuantity -= matchedQuantity;
+                
+                if (firstBuy.Quantity <= matchedQuantity)
+                {
+                    totalBought += firstBuy.Quantity * firstBuy.Price;
+                    totalBoughtQuantity += firstBuy.Quantity;
+                    remainingBuyOps.RemoveAt(0);
+                }
+                else
+                {
+                    totalBought += matchedQuantity * firstBuy.Price;
+                    totalBoughtQuantity += matchedQuantity;
+                    remainingBuyOps[0] = (firstBuy.Type, firstBuy.Date, firstBuy.Quantity - matchedQuantity, firstBuy.Price);
+                }
+            }
+        }
+        
+        // Remaining buy operations are open positions
+        openBuyOperations = remainingBuyOps;
+        
+        // Calculate realized profit
+        analysis.RealizedAbsoluteProfit = completedTrades.Sum(t => t.AbsoluteProfit);
+        analysis.RealizedRelativeProfit = totalBought > 0 ? (analysis.RealizedAbsoluteProfit / totalBought) * 100 : 0;
+        
+        // Calculate open position metrics
+        analysis.OpenPositionQuantity = openBuyOperations.Sum(o => o.Quantity);
+        analysis.TotalInvested = openBuyOperations.Sum(o => o.Quantity * o.Price);
+        analysis.AverageBuyPrice = analysis.OpenPositionQuantity > 0 ? analysis.TotalInvested / analysis.OpenPositionQuantity : 0;
+        
+        // Calculate unrealized profit (only if current price is provided)
+        if (currentPrice > 0 && analysis.OpenPositionQuantity > 0)
+        {
+            var currentValue = analysis.OpenPositionQuantity * currentPrice;
+            analysis.UnrealizedAbsoluteProfit = currentValue - analysis.TotalInvested;
+            analysis.UnrealizedRelativeProfit = analysis.TotalInvested > 0 ? (analysis.UnrealizedAbsoluteProfit / analysis.TotalInvested) * 100 : 0;
+        }
+        
+        // Calculate total profit
+        analysis.TotalAbsoluteProfit = analysis.RealizedAbsoluteProfit + analysis.UnrealizedAbsoluteProfit;
+        var totalInvestment = totalBought + analysis.TotalInvested;
+        analysis.TotalRelativeProfit = totalInvestment > 0 ? (analysis.TotalAbsoluteProfit / totalInvestment) * 100 : 0;
+        
+        analysis.CompletedTrades = completedTrades;
+        
+        return analysis;
+    }
+
+    public void LogProfitAnalysis(ProfitAnalysis analysis)
+    {
+        Logger.LogInformation("=== PROFIT ANALYSIS ===");
+        Logger.LogInformation($"Total Absolute Profit: {analysis.TotalAbsoluteProfit:F4}");
+        Logger.LogInformation($"Total Relative Profit: {analysis.TotalRelativeProfit:F2}%");
+        Logger.LogInformation("--- Realized Profit ---");
+        Logger.LogInformation($"Realized Absolute Profit: {analysis.RealizedAbsoluteProfit:F4}");
+        Logger.LogInformation($"Realized Relative Profit: {analysis.RealizedRelativeProfit:F2}%");
+        Logger.LogInformation("--- Unrealized Profit ---");
+        Logger.LogInformation($"Unrealized Absolute Profit: {analysis.UnrealizedAbsoluteProfit:F4}");
+        Logger.LogInformation($"Unrealized Relative Profit: {analysis.UnrealizedRelativeProfit:F2}%");
+        Logger.LogInformation("--- Position Info ---");
+        Logger.LogInformation($"Open Position Quantity: {analysis.OpenPositionQuantity}");
+        Logger.LogInformation($"Total Invested in Open Positions: {analysis.TotalInvested:F4}");
+        Logger.LogInformation($"Average Buy Price: {analysis.AverageBuyPrice:F4}");
+        Logger.LogInformation($"Completed Trades: {analysis.CompletedTrades.Count}");
+        
+        if (analysis.CompletedTrades.Any())
+        {
+            Logger.LogInformation("--- Recent Completed Trades ---");
+            var recentTrades = analysis.CompletedTrades.TakeLast(5);
+            foreach (var trade in recentTrades)
+            {
+                Logger.LogInformation($"Trade: {trade.Quantity} lots @ {trade.BuyPrice:F4} -> {trade.SellPrice:F4}, " +
+                    $"Profit: {trade.AbsoluteProfit:F4} ({trade.RelativeProfit:F2}%), " +
+                    $"Period: {(trade.SellDate - trade.BuyDate).TotalMinutes:F1}min");
+            }
+        }
+        Logger.LogInformation("=======================");
+    }
+}
+
+public class ProfitAnalysis
+{
+    public decimal TotalAbsoluteProfit { get; set; }
+    public decimal TotalRelativeProfit { get; set; }
+    public decimal RealizedAbsoluteProfit { get; set; }
+    public decimal RealizedRelativeProfit { get; set; }
+    public decimal UnrealizedAbsoluteProfit { get; set; }
+    public decimal UnrealizedRelativeProfit { get; set; }
+    public decimal TotalInvested { get; set; }
+    public long OpenPositionQuantity { get; set; }
+    public decimal AverageBuyPrice { get; set; }
+    public List<TradeProfit> CompletedTrades { get; set; } = new List<TradeProfit>();
+}
+
+public class TradeProfit
+{
+    public DateTime BuyDate { get; set; }
+    public DateTime SellDate { get; set; }
+    public long Quantity { get; set; }
+    public decimal BuyPrice { get; set; }
+    public decimal SellPrice { get; set; }
+    public decimal AbsoluteProfit { get; set; }
+    public decimal RelativeProfit { get; set; }
+}

--- a/csharp/TraderBot/Program.cs
+++ b/csharp/TraderBot/Program.cs
@@ -14,6 +14,7 @@ var host = builder
             var section = context.Configuration.GetSection(nameof(TradingSettings));
             return section.Get<TradingSettings>();
         });
+        services.AddSingleton<ProfitCalculationService>();
         services.AddHostedService<TradingService>();
         services.AddInvestApiClient((_, settings) =>
         {

--- a/csharp/TraderBot/TraderBot.csproj
+++ b/csharp/TraderBot/TraderBot.csproj
@@ -15,6 +15,10 @@
         <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.2" />
         <PackageReference Include="Platform.Data.Doublets.Sequences" Version="0.1.1" />
         <PackageReference Include="Tinkoff.InvestApi" Version="0.6.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" PrivateAssets="all" />
+        <PackageReference Include="Moq" Version="4.20.72" />
     </ItemGroup>
 
 </Project>

--- a/csharp/TraderBot/TradingService.cs
+++ b/csharp/TraderBot/TradingService.cs
@@ -39,13 +39,15 @@ public class TradingService : BackgroundService
     protected readonly ConcurrentDictionary<string, OrderState> ActiveSellOrders;
     protected readonly ConcurrentDictionary<decimal, long> LotsSets;
     protected readonly ConcurrentDictionary<string, decimal> ActiveSellOrderSourcePrice;
+    protected readonly ProfitCalculationService ProfitService;
 
-    public TradingService(ILogger<TradingService> logger, InvestApiClient investApi, IHostApplicationLifetime lifetime, TradingSettings settings)
+    public TradingService(ILogger<TradingService> logger, InvestApiClient investApi, IHostApplicationLifetime lifetime, TradingSettings settings, ProfitCalculationService profitService)
     {
         Logger = logger;
         InvestApi = investApi;
         Lifetime = lifetime;
         Settings = settings;
+        ProfitService = profitService;
         Logger.LogInformation($"Instrument: {settings.Instrument}");
         Logger.LogInformation($"Ticker: {settings.Ticker}");
         Logger.LogInformation($"CashCurrency: {settings.CashCurrency}");
@@ -257,6 +259,13 @@ public class TradingService : BackgroundService
 
         var openOperations = GetOpenOperations();
         // Logger.LogInformation($"Open operations count: {openOperations.Count}");
+        
+        // Calculate and log profit analysis
+        var allOperations = GetAllOperations();
+        var currentPrice = GetCurrentMarketPrice();
+        var profitAnalysis = ProfitService.CalculateProfit(allOperations, currentPrice);
+        ProfitService.LogProfitAnalysis(profitAnalysis);
+        
         var openOperationsGroupedByPrice = openOperations.GroupBy(operation => operation.Price).ToList();
 
         var deletedLotsSets = new List<decimal>();
@@ -801,6 +810,56 @@ public class TradingService : BackgroundService
         }
 
         return openOperations;
+    }
+
+    private OperationsList GetAllOperations()
+    {
+        DateTime accountOpenDate =  DateTime.SpecifyKind(CurrentAccount.OpenedDate.ToDateTime(), DateTimeKind.Utc).AddHours(-3);
+        DateTime lastCheckpoint = DateTime.SpecifyKind(LastOperationsCheckpoint, DateTimeKind.Utc).AddHours(-3);
+        DateTime from = new [] { accountOpenDate, lastCheckpoint }.Max();
+        var operations = InvestApi.Operations.GetOperations(new OperationsRequest
+        {
+            AccountId = CurrentAccount.Id,
+            State = OperationState.Executed,
+            Figi = Figi,
+            From = Timestamp.FromDateTime(from),
+            To = Timestamp.FromDateTime(DateTime.UtcNow.AddDays(4))
+        }).Operations.Select<Operation, (OperationType Type, DateTime Date, long Quantity, decimal Price)>(o => (o.OperationType, o.Date.ToDateTime(), o.GetActualQuantity(), o.Price)).OrderBy(x => x.Date).ToList();
+        
+        return operations;
+    }
+
+    private decimal GetCurrentMarketPrice()
+    {
+        try
+        {
+            var orderBook = InvestApi.MarketData.GetOrderBook(new GetOrderBookRequest
+            {
+                Figi = Figi,
+                Depth = 1
+            });
+            
+            if (orderBook.Bids.Count > 0 && orderBook.Asks.Count > 0)
+            {
+                var bestBid = QuotationToDecimal(orderBook.Bids.First().Price);
+                var bestAsk = QuotationToDecimal(orderBook.Asks.First().Price);
+                return (bestBid + bestAsk) / 2; // Mid price
+            }
+            else if (orderBook.Bids.Count > 0)
+            {
+                return QuotationToDecimal(orderBook.Bids.First().Price);
+            }
+            else if (orderBook.Asks.Count > 0)
+            {
+                return QuotationToDecimal(orderBook.Asks.First().Price);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning($"Failed to get current market price: {ex.Message}");
+        }
+        
+        return 0; // Return 0 if unable to get current price
     }
 
     private async Task<PostOrderResponse> PlaceSellOrder(long amount, decimal price)


### PR DESCRIPTION
## 🤖 AI-Powered Solution

This pull request implements automatic profit calculation for the TraderBot, displaying both absolute and relative profit values as requested in issue #201.

### 📋 Issue Reference
Fixes #201

### 🚀 Implementation Details

**New Components:**
- `ProfitCalculationService`: Core service for calculating profits using FIFO (First-In-First-Out) methodology
- `ProfitAnalysis`: Data model containing comprehensive profit metrics
- `TradeProfit`: Model representing individual completed trades

**Key Features:**
- **Absolute Profit**: Displays monetary profit/loss in the trading currency
- **Relative Profit**: Shows percentage-based profit/loss calculations
- **Realized vs Unrealized**: Separates completed trades from open positions
- **FIFO Matching**: Uses industry-standard First-In-First-Out method for trade matching
- **Current Market Integration**: Calculates unrealized profits using live market prices
- **Detailed Trade History**: Tracks individual trade profitability and duration

**Profit Metrics Displayed:**
- Total Absolute Profit (realized + unrealized)
- Total Relative Profit (percentage)
- Realized Absolute Profit from completed trades
- Realized Relative Profit percentage
- Unrealized Absolute Profit from open positions
- Unrealized Relative Profit percentage
- Open position statistics (quantity, average buy price, total invested)
- Recent completed trades with individual profit metrics

**Integration Points:**
- Integrated into `TradingService.SyncLots()` method for regular profit updates
- Uses existing operation tracking infrastructure
- Leverages current market price from order book data
- Logs comprehensive profit analysis during bot operation

### 🧪 Testing
- Comprehensive unit test suite with 6 test scenarios
- Tests cover empty operations, buy-only scenarios, complex FIFO matching
- Validates both profitable and loss scenarios
- Ensures accurate percentage calculations

### 📊 Usage Example
The bot now automatically logs profit analysis like this:
```
=== PROFIT ANALYSIS ===
Total Absolute Profit: 245.5000
Total Relative Profit: 12.34%
--- Realized Profit ---
Realized Absolute Profit: 180.0000
Realized Relative Profit: 15.00%
--- Unrealized Profit ---
Unrealized Absolute Profit: 65.5000
Unrealized Relative Profit: 8.76%
--- Position Info ---
Open Position Quantity: 25
Total Invested in Open Positions: 2750.0000
Average Buy Price: 110.0000
Completed Trades: 8
--- Recent Completed Trades ---
Trade: 10 lots @ 100.0000 -> 115.0000, Profit: 150.0000 (15.00%), Period: 45.2min
...
=======================
```

### ✅ Test Results
All 6 unit tests pass successfully:
- ✅ Empty operations handling
- ✅ Buy-only operations with unrealized profit
- ✅ Buy and sell operations with realized profit
- ✅ Complex FIFO matching scenarios
- ✅ Profitable trade calculations
- ✅ Loss trade calculations

---
*This PR was implemented by the AI issue solver*