### PR TITLE
Increase early sell limit for TRUR to 1,000,000

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Bot/issues/199
+Your prepared branch: issue-199-189dca0a
+Your prepared working directory: /tmp/gh-issue-solver-1757584358580
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Bot/issues/199
-Your prepared branch: issue-199-189dca0a
-Your prepared working directory: /tmp/gh-issue-solver-1757584358580
-
-Proceed.

--- a/csharp/TraderBot/appsettings.TRUR.json
+++ b/csharp/TraderBot/appsettings.TRUR.json
@@ -22,7 +22,7 @@
     "MinimumMarketOrderSizeToSell": 0,
     "MinimumTimeToBuy": "09:00:00",
     "MaximumTimeToBuy": "14:45:00",
-    "EarlySellOwnedLotsDelta": 300000,
+    "EarlySellOwnedLotsDelta": 1000000,
     "EarlySellOwnedLotsMultiplier": 0,
     "LoadOperationsFrom": "2025-03-01T00:00:01.3389860Z"
   }


### PR DESCRIPTION
## Summary
- Increased `EarlySellOwnedLotsDelta` from 300,000 to 1,000,000 for TRUR in `appsettings.TRUR.json`
- This change increases the threshold for market order size needed to trigger immediate sell orders

## Changes Made
- Modified `csharp/TraderBot/appsettings.TRUR.json`
- Changed `EarlySellOwnedLotsDelta` value from `300000` to `1000000`

## Context
This addresses issue #199 which requested to increase the early sell limit to 1,000,000 for TRUR.

The `EarlySellOwnedLotsDelta` is used in the trading logic to determine when to trigger immediate sell orders based on market order book conditions. The complete formula is:
`EarlySellOwnedLotsDelta + EarlySellOwnedLotsMultiplier * Lots requested to sell`

## Test Plan
- [x] Verified the configuration file syntax is correct
- [x] Confirmed the solution builds successfully with the new configuration
- [x] No code changes required - only configuration update

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #199