### PR TITLE
Trader: Add log of request's tracking ID for efficient Tinkoff support communication

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Bot/issues/184
-Your prepared branch: issue-184-61e8c188
-Your prepared working directory: /tmp/gh-issue-solver-1757585312259
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Bot/issues/184
+Your prepared branch: issue-184-61e8c188
+Your prepared working directory: /tmp/gh-issue-solver-1757585312259
+
+Proceed.

--- a/csharp/TraderBot/TradingService.cs
+++ b/csharp/TraderBot/TradingService.cs
@@ -826,8 +826,17 @@ public class TradingService : BackgroundService
         // {
         //     throw new InvalidOperationException($"Not enough amount to sell {amount} assets. Available amount: {securityPosition.Balance}");
         // }
-        var response = await InvestApi.Orders.PostOrderAsync(sellOrderRequest).ResponseAsync;
+        using var call = InvestApi.Orders.PostOrderAsync(sellOrderRequest);
+        var headers = await call.ResponseHeadersAsync;
+        var response = await call.ResponseAsync;
+        
+        var trackingId = headers.GetValue("x-tracking-id");
         Logger.LogInformation($"Sell order placed: {response}");
+        if (!string.IsNullOrEmpty(trackingId))
+        {
+            Logger.LogInformation($"Tinkoff request tracking ID: {trackingId}");
+        }
+        
         return response;
     }
 
@@ -847,21 +856,39 @@ public class TradingService : BackgroundService
         // {
         //     throw new InvalidOperationException($"Not enough money to buy {CurrentInstrument.Figi} asset.");
         // }
-        var response = await InvestApi.Orders.PostOrderAsync(buyOrderRequest).ResponseAsync;
+        using var call = InvestApi.Orders.PostOrderAsync(buyOrderRequest);
+        var headers = await call.ResponseHeadersAsync;
+        var response = await call.ResponseAsync;
+        
+        var trackingId = headers.GetValue("x-tracking-id");
         var total = amount * price;
         SetCashBalance(CashBalanceFree - total, CashBalanceLocked + total);
         Logger.LogInformation($"Buy order placed: {response}");
+        if (!string.IsNullOrEmpty(trackingId))
+        {
+            Logger.LogInformation($"Tinkoff request tracking ID: {trackingId}");
+        }
+        
         return response;
     }
 
     private async Task<CancelOrderResponse> CancelOrder(string orderId)
     {
-        var response = await InvestApi.Orders.CancelOrderAsync(new CancelOrderRequest
+        using var call = InvestApi.Orders.CancelOrderAsync(new CancelOrderRequest
         {
             AccountId = CurrentAccount.Id,
             OrderId = orderId,
         });
+        var headers = await call.ResponseHeadersAsync;
+        var response = await call.ResponseAsync;
+        
+        var trackingId = headers.GetValue("x-tracking-id");
         Logger.LogInformation($"Order cancelled: {response}");
+        if (!string.IsNullOrEmpty(trackingId))
+        {
+            Logger.LogInformation($"Tinkoff request tracking ID: {trackingId}");
+        }
+        
         return response;
     }
 

--- a/examples/TrackingIdExample.cs
+++ b/examples/TrackingIdExample.cs
@@ -1,0 +1,45 @@
+using System;
+using Grpc.Core;
+using Microsoft.Extensions.Logging;
+
+namespace TraderBot.Examples
+{
+    /// <summary>
+    /// This example demonstrates how the tracking ID logging would work
+    /// when the Tinkoff API returns the x-tracking-id header
+    /// </summary>
+    public class TrackingIdExample
+    {
+        private readonly ILogger<TrackingIdExample> _logger;
+
+        public TrackingIdExample(ILogger<TrackingIdExample> logger)
+        {
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Example of how tracking ID is extracted and logged
+        /// This simulates what happens in the actual PlaceBuyOrder/PlaceSellOrder/CancelOrder methods
+        /// </summary>
+        public void SimulateTrackingIdLogging()
+        {
+            // Simulate a response with x-tracking-id header
+            var metadata = new Metadata
+            {
+                { "x-tracking-id", "550e8400-e29b-41d4-a716-446655440000" }
+            };
+
+            // Extract tracking ID (as done in the actual implementation)
+            var trackingId = metadata.GetValue("x-tracking-id");
+
+            // Log the tracking ID (as done in the actual implementation)
+            _logger.LogInformation($"Buy order placed: [order response details]");
+            if (!string.IsNullOrEmpty(trackingId))
+            {
+                _logger.LogInformation($"Tinkoff request tracking ID: {trackingId}");
+            }
+
+            Console.WriteLine($"Tracking ID logged: {trackingId}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Added logging of `x-tracking-id` header from Tinkoff API responses in TraderBot
- Modified `PlaceBuyOrder`, `PlaceSellOrder`, and `CancelOrder` methods to capture and log tracking IDs
- Added example demonstrating tracking ID extraction for future reference

## Implementation Details
The solution modifies the order handling methods to:
1. Use `using var call = InvestApi.Orders.PostOrderAsync(...)` pattern to access response headers
2. Extract `x-tracking-id` from response headers using `headers.GetValue("x-tracking-id")`
3. Log the tracking ID with a clear message: `"Tinkoff request tracking ID: {trackingId}"`

## Why This is Important
- Tracking IDs are essential for efficient communication with Tinkoff technical support
- When reporting issues to Tinkoff, providing the tracking ID speeds up incident resolution
- Each API request receives a unique UUID tracking ID that helps support teams debug issues

## Test Plan
- [x] Code compiles without errors
- [x] Build passes with existing warnings unchanged
- [x] Added example demonstrating tracking ID extraction pattern
- [x] Logging format is clear and consistent across all order methods

## Files Changed
- `csharp/TraderBot/TradingService.cs`: Added tracking ID logging to order methods
- `examples/TrackingIdExample.cs`: Added example demonstrating the tracking ID pattern

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #184