### PR TITLE
Trader: add timer to restart subscriptions if no data received

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Bot/issues/183
+Your prepared branch: issue-183-f7d0021d
+Your prepared working directory: /tmp/gh-issue-solver-1757585904449
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Bot/issues/183
-Your prepared branch: issue-183-f7d0021d
-Your prepared working directory: /tmp/gh-issue-solver-1757585904449
-
-Proceed.

--- a/csharp/TraderBot/TradingService.cs
+++ b/csharp/TraderBot/TradingService.cs
@@ -19,6 +19,7 @@ public class TradingService : BackgroundService
     protected static readonly TimeSpan RefreshInterval = TimeSpan.FromSeconds(10);
     protected static readonly TimeSpan SyncInterval = TimeSpan.FromSeconds(20);
     protected static readonly TimeSpan WaitOutputInterval = TimeSpan.FromSeconds(20);
+    protected static readonly TimeSpan SubscriptionTimeoutInterval = TimeSpan.FromMinutes(5);
     protected readonly InvestApiClient InvestApi;
     protected readonly ILogger<TradingService> Logger;
     protected readonly IHostApplicationLifetime Lifetime;
@@ -33,6 +34,8 @@ public class TradingService : BackgroundService
     protected long LastRefreshTicks;
     protected long LastSyncTicks;
     protected long LastWaitOutputTicks;
+    protected long LastTradesDataTicks;
+    protected long LastMarketDataTicks;
     protected TimeSpan MinimumTimeToBuy;
     protected TimeSpan MaximumTimeToBuy;
     protected readonly ConcurrentDictionary<string, OrderState> ActiveBuyOrders;
@@ -112,6 +115,9 @@ public class TradingService : BackgroundService
         LotsSets = new ConcurrentDictionary<decimal, long>();
         ActiveSellOrderSourcePrice = new ConcurrentDictionary<string, decimal>();
         LastOperationsCheckpoint = settings.LoadOperationsFrom;
+        var nowTicks = DateTime.UtcNow.Ticks;
+        LastTradesDataTicks = nowTicks;
+        LastMarketDataTicks = nowTicks;
     }
 
     protected async Task ReceiveTrades(CancellationToken cancellationToken)
@@ -122,6 +128,7 @@ public class TradingService : BackgroundService
         });
         await foreach (var data in tradesStream.ResponseStream.ReadAllAsync(cancellationToken))
         {
+            Interlocked.Exchange(ref LastTradesDataTicks, DateTime.UtcNow.Ticks);
             Logger.LogInformation($"Trade: {data}");
             if (data.PayloadCase == TradesStreamResponse.PayloadOneofCase.OrderTrades)
             {
@@ -349,14 +356,40 @@ public class TradingService : BackgroundService
             try
             {
                 await Refresh(forceReset: true);
-                await SendOrders(cancellationToken);
+                
+                using var timeoutCancellationTokenSource = new CancellationTokenSource();
+                using var combinedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCancellationTokenSource.Token);
+                
+                var sendOrdersTask = SendOrders(combinedCancellationTokenSource.Token);
+                var timeoutTask = CheckMarketDataTimeout(timeoutCancellationTokenSource, cancellationToken);
+                
+                await Task.WhenAny(sendOrdersTask, timeoutTask);
+                
+                if (timeoutTask.IsCompleted && !timeoutTask.IsCanceled)
+                {
+                    Logger.LogWarning("Market data subscription timeout detected, restarting subscription.");
+                    timeoutCancellationTokenSource.Cancel();
+                }
+                
+                try
+                {
+                    await sendOrdersTask;
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (OperationCanceledException)
+                {
+                    Logger.LogInformation("Market data subscription cancelled due to timeout, will restart.");
+                }
             }
             catch (Exception ex)
             {
                 if (!cancellationToken.IsCancellationRequested)
                 {
                     Logger.LogError(ex, "SendOrders exception.");
-                    await Task.Delay(RecoveryInterval);
+                    await Task.Delay(RecoveryInterval, cancellationToken);
                 }
             }
         }
@@ -369,16 +402,76 @@ public class TradingService : BackgroundService
             try
             {
                 await Refresh(forceReset: true);
-                await ReceiveTrades(cancellationToken);
+                
+                using var timeoutCancellationTokenSource = new CancellationTokenSource();
+                using var combinedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, timeoutCancellationTokenSource.Token);
+                
+                var receiveTradesTask = ReceiveTrades(combinedCancellationTokenSource.Token);
+                var timeoutTask = CheckTradesTimeout(timeoutCancellationTokenSource, cancellationToken);
+                
+                await Task.WhenAny(receiveTradesTask, timeoutTask);
+                
+                if (timeoutTask.IsCompleted && !timeoutTask.IsCanceled)
+                {
+                    Logger.LogWarning("Trades subscription timeout detected, restarting subscription.");
+                    timeoutCancellationTokenSource.Cancel();
+                }
+                
+                try
+                {
+                    await receiveTradesTask;
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    throw;
+                }
+                catch (OperationCanceledException)
+                {
+                    Logger.LogInformation("Trades subscription cancelled due to timeout, will restart.");
+                }
             }
             catch (Exception ex)
             {
                 if (!cancellationToken.IsCancellationRequested)
                 {
                     Logger.LogError(ex, "ReceiveTrades exception.");
-                    await Task.Delay(RecoveryInterval);
+                    await Task.Delay(RecoveryInterval, cancellationToken);
                 }
             }
+        }
+    }
+
+    protected async Task CheckTradesTimeout(CancellationTokenSource timeoutCancellationTokenSource, CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested && !timeoutCancellationTokenSource.Token.IsCancellationRequested)
+        {
+            var nowTicks = DateTime.UtcNow.Ticks;
+            var lastDataTicks = Interlocked.Read(ref LastTradesDataTicks);
+            
+            if (nowTicks - lastDataTicks > SubscriptionTimeoutInterval.Ticks)
+            {
+                Logger.LogWarning($"No trades data received for {SubscriptionTimeoutInterval.TotalMinutes} minutes, triggering restart.");
+                return;
+            }
+            
+            await Task.Delay(TimeSpan.FromSeconds(30), cancellationToken);
+        }
+    }
+    
+    protected async Task CheckMarketDataTimeout(CancellationTokenSource timeoutCancellationTokenSource, CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested && !timeoutCancellationTokenSource.Token.IsCancellationRequested)
+        {
+            var nowTicks = DateTime.UtcNow.Ticks;
+            var lastDataTicks = Interlocked.Read(ref LastMarketDataTicks);
+            
+            if (nowTicks - lastDataTicks > SubscriptionTimeoutInterval.Ticks)
+            {
+                Logger.LogWarning($"No market data received for {SubscriptionTimeoutInterval.TotalMinutes} minutes, triggering restart.");
+                return;
+            }
+            
+            await Task.Delay(TimeSpan.FromSeconds(30), cancellationToken);
         }
     }
 
@@ -402,6 +495,7 @@ public class TradingService : BackgroundService
         }, cancellationToken);
         await foreach (var data in marketDataStream.ResponseStream.ReadAllAsync(cancellationToken))
         {
+            Interlocked.Exchange(ref LastMarketDataTicks, DateTime.UtcNow.Ticks);
             // Logger.LogInformation($"data.PayloadCase: {data.PayloadCase}");
             if (data.PayloadCase == MarketDataResponse.PayloadOneofCase.SubscribeOrderBookResponse)
             {


### PR DESCRIPTION
## Summary

Implements a timer-based subscription restart mechanism to address issue #183 where trades subscription was broken after 17 days of uptime.

### Changes Made
- Added `SubscriptionTimeoutInterval` constant set to 5 minutes
- Added tracking fields for last data received time: `LastTradesDataTicks` and `LastMarketDataTicks`
- Implemented timeout monitoring methods: `CheckTradesTimeout` and `CheckMarketDataTimeout`
- Updated both subscription loops (`ReceiveTradesLoop` and `SendOrdersLoop`) to:
  - Run subscription tasks concurrently with timeout monitoring
  - Automatically restart subscriptions when no data is received within the timeout period
  - Log warnings when timeouts are detected for debugging purposes
- Fixed existing `Task.Delay` calls to properly handle cancellation tokens

### Technical Details
- Each subscription stream now updates its respective timestamp when data is received
- Timeout monitoring runs every 30 seconds and checks if data hasn't been received for over 5 minutes
- When a timeout is detected, the subscription is cancelled and automatically restarted
- The mechanism is transparent to the trading logic and maintains all existing functionality

### Test Plan
- [x] Code compiles successfully with no errors
- [x] Existing warnings remain unchanged (all pre-existing)
- [x] CI build workflow validates the changes
- [ ] Manual testing with subscription timeout simulation (recommended for production deployment)

This fix ensures the trader bot maintains reliable data streams and automatically recovers from silent subscription failures that previously required manual restarts.

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #183