### PR TITLE
Translate README to English and Russian

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Bot/issues/123
-Your prepared branch: issue-123-7b58012c
-Your prepared working directory: /tmp/gh-issue-solver-1757719437315
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Bot/issues/123
+Your prepared branch: issue-123-7b58012c
+Your prepared working directory: /tmp/gh-issue-solver-1757719437315
+
+Proceed.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Bot
+# Bot ([русская версия](README.ru.md))
 
 ## [VK bot](https://github.com/linksplatform/Bot/tree/main/python)
 This bot is created for programmers by programmers. Features are: personal Karma tracking, programmer's personal information storage, Wikipedia access, GitHub Copilot access.

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,0 +1,10 @@
+# Бот ([english version](README.md))
+
+## [VK бот](https://github.com/linksplatform/Bot/tree/main/python)
+Этот бот создан программистами для программистов. Возможности: отслеживание личной кармы, хранение персональной информации программистов, доступ к Википедии, доступ к GitHub Copilot.
+## [GitHub бот](https://github.com/linksplatform/Bot/tree/main/csharp/Platform.Bot)
+Бот, который может создавать "hello world" и имеет некоторые другие полезные функции.
+## [Discord бот](https://github.com/linksplatform/Bot/tree/AddDiscrodBot/csharp/DiscordBot)
+Бот, который может добавлять новых программистов в команду LinksPlatform из Discord в организацию GitHub.
+## [Торговый бот](https://github.com/linksplatform/Bot/tree/main/csharp/TraderBot)
+Реализация стратегии скальпинга.


### PR DESCRIPTION
## Summary

- Created Russian translation of the main README.md as README.ru.md
- Updated the English README.md to include cross-reference to the Russian version
- Followed the established pattern used in TraderBot for bilingual documentation

## Implementation Details

This solution provides both English and Russian versions of the README as requested in issue #123:

- **README.md**: English version with link to Russian version
- **README.ru.md**: Complete Russian translation with link back to English version

The translation includes all bot descriptions:
- VK bot for programmers with karma tracking and GitHub Copilot access
- GitHub bot with "hello world" capabilities
- Discord bot for team management
- Trader bot implementing scalping strategy

## Test plan

- [x] Verify both README files have proper cross-references
- [x] Confirm Russian translation is accurate and maintains the same structure
- [x] Ensure links and formatting are preserved in both versions

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #123