### PR TITLE
Fix: Disable votes on votes (#18)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Bot/issues/18
-Your prepared branch: issue-18-8178c886
-Your prepared working directory: /tmp/gh-issue-solver-1757819671184
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Bot/issues/18
+Your prepared branch: issue-18-8178c886
+Your prepared working directory: /tmp/gh-issue-solver-1757819671184
+
+Proceed.

--- a/python/modules/commands.py
+++ b/python/modules/commands.py
@@ -170,6 +170,10 @@ class Commands:
             if selected_user_id:
                 self.user = self.data_service.get_user(int(selected_user_id), self)
 
+        # Disable votes on bot messages (votes on votes)
+        if self.user and self.user.uid < 0:
+            return
+
         if self.user and (self.user.uid != self.from_id):
             operator = self.matched.group("operator")[0]
             amount = self.matched.group("amount")


### PR DESCRIPTION
## Summary

This PR fixes issue #18 by preventing users from voting on bot messages, specifically karma change messages.

### Changes Made

- Added a check in `apply_karma()` method to prevent voting when the target user has a negative UID (bot/group messages)
- This prevents users from voting on karma change messages posted by the bot

### Problem Solved

Previously, when a user voted on another user's message:
1. User A votes "++" on User B's message
2. Bot deletes User A's vote and posts "Карма изменена: [User B] [5]->[6]"
3. Users could vote on the bot's karma change message (unwanted behavior)

Now, votes on bot messages (UIDs < 0) are silently ignored, preventing "votes on votes".

### Test Plan

- [x] Verified syntax is correct
- [x] Tested logic with mock users (positive UIDs allow voting, negative UIDs prevent voting)
- [x] Confirmed the fix targets the specific issue without affecting normal voting functionality

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #18