### PR TITLE
Add missing programming languages (fish, QuakeC, OpenCL, CUDA)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Bot/issues/15
-Your prepared branch: issue-15-65117436
-Your prepared working directory: /tmp/gh-issue-solver-1757820384546
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Bot/issues/15
+Your prepared branch: issue-15-65117436
+Your prepared working directory: /tmp/gh-issue-solver-1757820384546
+
+Proceed.

--- a/python/config.py
+++ b/python/config.py
@@ -135,6 +135,10 @@ DEFAULT_PROGRAMMING_LANGUAGES = [
     r"X#",
     r"NVPTX",
     r"Nemerle",
+    r"fish",
+    r"QuakeC",
+    r"OpenCL",
+    r"CUDA",
 ]
 
 GITHUB_COPILOT_LANGUAGES = {


### PR DESCRIPTION
## Summary
• Added 4 missing programming languages to `DEFAULT_PROGRAMMING_LANGUAGES` list
• Languages added: fish (shell), QuakeC, OpenCL, CUDA
• These were requested in issue comments by community members

## Changes Made
- Extended `python/config.py` with additional language patterns
- All languages follow existing regex pattern format
- No breaking changes to existing functionality  

## Test plan  
- [x] Verify syntax is correct in config.py
- [x] Ensure new languages follow same pattern as existing ones
- [x] Confirm no duplicate entries exist

Fixes #15

🤖 Generated with [Claude Code](https://claude.ai/code)