### PR TITLE
Reduce bot message frequency to prevent spam

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+Issue to solve: https://github.com/linksplatform/Bot/issues/9
+Your prepared branch: issue-9-095eadd0
+Your prepared working directory: /tmp/gh-issue-solver-1757821076647
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,0 @@
-Issue to solve: https://github.com/linksplatform/Bot/issues/9
-Your prepared branch: issue-9-095eadd0
-Your prepared working directory: /tmp/gh-issue-solver-1757821076647
-
-Proceed.

--- a/csharp/Platform.Bot/Program.cs
+++ b/csharp/Platform.Bot/Program.cs
@@ -71,7 +71,7 @@ namespace Platform.Bot
             var minimumInteractionIntervalOption = new Option<int>(
                 name: "--minimum-interaction-interval",
                 description: "Minimum interaction interval in seconds.",
-                getDefaultValue: () => 60);
+                getDefaultValue: () => 300);
 
             var rootCommand = new RootCommand("Sample app for System.CommandLine")
             {

--- a/csharp/Platform.Bot/Trackers/IssueTracker.cs
+++ b/csharp/Platform.Bot/Trackers/IssueTracker.cs
@@ -33,6 +33,14 @@ namespace Platform.Bot.Trackers
 
         /// <summary>
         /// <para>
+        /// Tracks processed issues to prevent duplicate actions.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        private HashSet<string> _processedIssues { get; } = new HashSet<string>();
+
+        /// <summary>
+        /// <para>
         /// Initializes a new <see cref="IssueTracker"/> instance.
         /// </para>
         /// <para></para>
@@ -66,6 +74,15 @@ namespace Platform.Bot.Trackers
             var allIssues = _storage.GetIssues();
             foreach (var issue in allIssues)
             {
+                // Create a unique key for each issue-trigger combination to prevent duplicate processing
+                var issueKey = $"{issue.Repository.FullName}#{issue.Number}";
+                
+                // Skip if this issue has already been processed
+                if (_processedIssues.Contains(issueKey))
+                {
+                    continue;
+                }
+
                 foreach (var trigger in _triggers)
                 {
                     if (cancellationToken.IsCancellationRequested)
@@ -75,6 +92,9 @@ namespace Platform.Bot.Trackers
                     if (await trigger.Condition(issue))
                     {
                         await trigger.Action(issue);
+                        // Mark issue as processed after successful action
+                        _processedIssues.Add(issueKey);
+                        break; // Only process one trigger per issue to prevent conflicts
                     }
                 }
             }

--- a/csharp/Platform.Bot/Trackers/PullRequestTracker.cs
+++ b/csharp/Platform.Bot/Trackers/PullRequestTracker.cs
@@ -35,6 +35,14 @@ namespace Platform.Bot.Trackers
 
         /// <summary>
         /// <para>
+        /// Tracks processed pull requests to prevent duplicate actions.
+        /// </para>
+        /// <para></para>
+        /// </summary>
+        private HashSet<string> _processedPullRequests = new HashSet<string>();
+
+        /// <summary>
+        /// <para>
         /// Initializes a new <see cref="IssueTracker"/> instance.
         /// </para>
         /// <para></para>
@@ -75,10 +83,22 @@ namespace Platform.Bot.Trackers
                         {
                             return;
                         }
+                        
+                        // Create a unique key for each pull request to prevent duplicate processing
+                        var pullRequestKey = $"{repository.FullName}#{pullRequest.Number}";
+                        
+                        // Skip if this pull request has already been processed
+                        if (_processedPullRequests.Contains(pullRequestKey))
+                        {
+                            continue;
+                        }
+                        
                         var detailedPullRequest = _storage.Client.PullRequest.Get(repository.Id, pullRequest.Number).AwaitResult();
                         if (await trigger.Condition(detailedPullRequest))
                         {
                             await trigger.Action(detailedPullRequest);
+                            // Mark pull request as processed after successful action
+                            _processedPullRequests.Add(pullRequestKey);
                         }
                     }
                 }

--- a/csharp/Storage/RemoteStorage/GitHubStorage.cs
+++ b/csharp/Storage/RemoteStorage/GitHubStorage.cs
@@ -103,12 +103,21 @@ namespace Storage.Remote.GitHub
                 Since = lastIssue
             };
             var issues = Client.Issue.GetAllForCurrent(request).Result;
+            
+            // Always update lastIssue to current time to prevent reprocessing the same timeframe
+            // even when there are no new issues
+            var now = DateTimeOffset.Now;
             if (issues.Count != 0)
             {
-                lastIssue = issues.Max(x => x.CreatedAt);
-                return issues;
+                var maxIssueTime = issues.Max(x => x.CreatedAt);
+                lastIssue = maxIssueTime > now ? maxIssueTime : now;
             }
-            return new List<Issue>();
+            else
+            {
+                lastIssue = now;
+            }
+            
+            return issues;
         }
 
         public Task<IReadOnlyList<GitHubCommit>> GetCommits(long repositoryId, CommitRequest commitRequest) => Client.Repository.Commit.GetAll(repositoryId, commitRequest);


### PR DESCRIPTION
## Summary
- Increased default interaction interval from 60 to 300 seconds (5 minutes) to reduce polling frequency
- Fixed GitHubStorage.GetIssues() timestamp tracking bug that caused reprocessing of the same timeframes repeatedly
- Added processed item tracking to prevent duplicate actions on issues and pull requests
- Ensured only one trigger processes each issue to prevent conflicts

## Problem
The bot was sending excessive messages due to:
1. **Aggressive polling**: 60-second intervals were too frequent
2. **Timestamp bug**: The `lastIssue` timestamp wasn't updated when no new issues were found, causing the same timeframes to be repeatedly processed
3. **No duplicate prevention**: Issues and PRs were processed repeatedly without tracking what had already been handled
4. **Multiple trigger execution**: Multiple triggers could act on the same issue causing redundant actions

## Solution
1. **Increased polling interval**: Changed default from 60 to 300 seconds (5 minutes)
2. **Fixed timestamp logic**: Always update `lastIssue` to current time to prevent reprocessing 
3. **Added deduplication**: Track processed issues/PRs using HashSet with unique keys (`repo#number`)
4. **Single trigger per issue**: Added break statement to ensure only one trigger processes each issue

## Test plan
- [x] Verify code compiles successfully
- [x] Confirm reduced default polling frequency 
- [ ] Test in production environment to verify reduced message frequency
- [ ] Monitor for any missed legitimate triggers

🤖 Generated with [Claude Code](https://claude.ai/code)


---

Resolves #9